### PR TITLE
dont overried env node url

### DIFF
--- a/node/worker/template_worker.py
+++ b/node/worker/template_worker.py
@@ -392,9 +392,6 @@ class OrchestratorEngine:
             "id": self.orchestrator_run.consumer_id,
         }
 
-        # set environment url TODO: here override the environment url. is this correct?
-        self.orchestrator_run.environment_deployments[0].environment_node_url = LOCAL_DB_URL
-
 
     async def init_run(self):
         logger.info("Initializing orchestrator run")


### PR DESCRIPTION
- Environment class in sdk now uses http call to create/add table/rows
- here we avoid overriding env node 