### PR TITLE
Improve Docker Container Signal Handling & Graceful Shutdown

### DIFF
--- a/Dockerfile-node-dev
+++ b/Dockerfile-node-dev
@@ -31,11 +31,6 @@ RUN curl -sSf https://install.surrealdb.com | sh
 
 EXPOSE 7001 7002
 
-# run db migrations / config & server
-CMD (poetry run python -m node.storage.db.init_db | tee /dev/stdout) && \
-    (poetry run python -m node.storage.hub.init_hub | tee /dev/stdout) && \
-    (poetry run python -m node.storage.hub.init_hub --user | tee /dev/stdout) && \
-    ((poetry run celery -A node.worker.main:app worker --loglevel=info | tee /dev/stdout) & ) && \
-    (poetry run python -m node.server.server --communication-protocol http --port 7001 | tee /dev/stdout) & \
-    poetry run python -m node.server.server --communication-protocol ws --port 7002 | tee /dev/stdout
+RUN chmod +x /app/entrypoint.sh
+CMD ["/app/entrypoint.sh"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     container_name: node-app
     build:
       dockerfile: Dockerfile-node-dev
+    init: true
+    stop_grace_period: 30s
     env_file:
       - ./.env
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Run DB migrations and hub initialization
+poetry run python -m node.storage.db.init_db | tee /dev/stdout
+poetry run python -m node.storage.hub.init_hub | tee /dev/stdout
+poetry run python -m node.storage.hub.init_hub --user | tee /dev/stdout
+
+# Start celery worker detached
+nohup poetry run celery -A node.worker.main:app worker --loglevel=info > /dev/stdout 2>&1 &
+
+# Start WS server detached
+nohup poetry run python -m node.server.server --communication-protocol ws --port 7002 > /dev/stdout 2>&1 &
+
+# Run HTTP server as the main foreground process so it receives SIGTERM
+exec poetry run python -m node.server.server --communication-protocol http --port 7001


### PR DESCRIPTION
This PR addresses issues with graceful shutdown of the node-app container in our Docker environment (systemd deployments remain unaffected). The changes ensure that the HTTP server properly receives SIGTERM so that node unregistration is executed before termination.

`docker-compose.yml`
- Added init: true and set stop_grace_period: 30s to allow the container sufficient time for graceful shutdown.

`Dockerfile-node-dev`
- Updated the CMD to execute an entrypoint script, ensuring the main process receives signals directly.

`entrypoint.sh`
- Modified to launch the WS server and Celery worker in detached mode using nohup, and run the HTTP server as the foreground process (via exec) so it properly handles SIGTERM.