### PR TITLE
chore: use logger.debug

### DIFF
--- a/node/module_manager.py
+++ b/node/module_manager.py
@@ -143,8 +143,8 @@ async def install_module_with_lock(module: Union[Dict, Module]):
         if installed_version == run_version:
             logger.info("Running poetry update")
             update_output = run_poetry_command(["update", f"{module_name}"])
-            logger.info(f"Update output: {update_output}")
-            logger.info(f"Module {module_name} version {run_version} is already installed")
+            logger.debug(f"Update output: {update_output}")
+            logger.debug(f"Module {module_name} version {run_version} is already installed")
             return True
 
     lock_file = Path(MODULES_SOURCE_DIR) / f"{module_name}.lock"
@@ -243,7 +243,7 @@ async def download_persona_from_ipfs(persona_url: str, personas_base_dir: Path):
             logger.info(f"Persona {persona_folder_name} already exists")
             # remove the directory
             shutil.rmtree(persona_dir)
-            logger.info(f"Removed existing persona directory: {persona_dir}")
+            logger.debug(f"Removed existing persona directory: {persona_dir}")
 
         persona_temp_zip_path = download_from_ipfs(persona_ipfs_hash, personas_base_dir)
         unzip_file(persona_temp_zip_path, persona_dir)
@@ -264,7 +264,7 @@ async def download_persona_from_git(repo_url: str, personas_base_dir: Path):
         if persona_dir.exists():
             # remove the directory
             shutil.rmtree(persona_dir)
-            logger.info(f"Removed existing persona directory: {persona_dir}")
+            logger.debug(f"Removed existing persona directory: {persona_dir}")
             # clone the repository again
             Repo.clone_from(repo_url, persona_dir)
             logger.info(f"Successfully cloned persona: {repo_name}")
@@ -283,7 +283,7 @@ async def download_persona_from_git(repo_url: str, personas_base_dir: Path):
 def install_module_from_ipfs(module_name: str, module_version: str, module_source_url: str):
     logger.info(f"Installing/updating module {module_name} version {module_version}")
     modules_source_dir = Path(MODULES_SOURCE_DIR) / module_name
-    logger.info(f"Module path exists: {modules_source_dir.exists()}")
+    logger.debug(f"Module path exists: {modules_source_dir.exists()}")
     try:
         module_ipfs_hash = module_source_url.split("ipfs://")[1]
         module_temp_zip_path = download_from_ipfs(module_ipfs_hash, MODULES_SOURCE_DIR)
@@ -294,38 +294,38 @@ def install_module_from_ipfs(module_name: str, module_version: str, module_sourc
         venv_dir = modules_source_dir / ".venv"
         if venv_dir.exists():
             shutil.rmtree(venv_dir)
-            logger.info(f"Removed existing venv directory: {venv_dir}")
+            logger.debug(f"Removed existing venv directory: {venv_dir}")
 
     except Exception as e:
         error_msg = f"Error installing {module_name}: {str(e)}"
         logger.error(error_msg)
-        logger.info(f"Traceback: {traceback.format_exc()}")
+        logger.error(f"Traceback: {traceback.format_exc()}")
         raise RuntimeError(error_msg) from e
 
 
 def install_module_from_git(module_name: str, module_version: str, module_source_url: str):
     logger.info(f"Installing/updating module {module_name} version {module_version}")
     modules_source_dir = Path(MODULES_SOURCE_DIR) / module_name
-    logger.info(f"Module path exists: {modules_source_dir.exists()}")
+    logger.debug(f"Module path exists: {modules_source_dir.exists()}")
     try:
         if modules_source_dir.exists():
-            logger.info(f"Updating existing repository for {module_name}")
+            logger.debug(f"Updating existing repository for {module_name}")
             repo = Repo(modules_source_dir)
             repo.remotes.origin.fetch()
             repo.git.checkout(module_version)
-            logger.info(f"Successfully updated {module_name} to version {module_version}")
+            logger.debug(f"Successfully updated {module_name} to version {module_version}")
         else:
             # Clone new repository
-            logger.info(f"Cloning new repository for {module_name}")
+            logger.debug(f"Cloning new repository for {module_name}")
             Repo.clone_from(module_source_url, modules_source_dir)
             repo = Repo(modules_source_dir)
             repo.git.checkout(module_version)
-            logger.info(f"Successfully cloned {module_name} version {module_version}")
+            logger.debug(f"Successfully cloned {module_name} version {module_version}")
 
     except Exception as e:
         error_msg = f"Error installing {module_name}: {str(e)}"
         logger.error(error_msg)
-        logger.info(f"Traceback: {traceback.format_exc()}")
+        logger.error(f"Traceback: {traceback.format_exc()}")
         if "Dependency conflict detected" in str(e):
             error_msg += "\nThis is likely due to a mismatch in naptha-sdk versions between the module and the main project."
         raise RuntimeError(error_msg) from e
@@ -361,7 +361,7 @@ def run_poetry_command(command, module_name=None):
 def install_module(module_name: str, module_version: str, module_source_url: str):
     logger.info(f"Installing/updating module {module_name} version {module_version}")
     modules_source_dir = Path(MODULES_SOURCE_DIR) / module_name
-    logger.info(f"Module path exists: {modules_source_dir.exists()}")
+    logger.debug(f"Module path exists: {modules_source_dir.exists()}")
 
     try:
         if "ipfs://" in module_source_url:
@@ -378,8 +378,8 @@ def install_module(module_name: str, module_version: str, module_source_url: str
 
         # Capture stdout/stderr
         proc = subprocess.run(install_cmd, capture_output=True, text=True)
-        logger.info(f"Pip install stdout: {proc.stdout}")
-        logger.info(f"Pip install stderr: {proc.stderr}")
+        logger.debug(f"Pip install stdout: {proc.stdout}")
+        logger.debug(f"Pip install stderr: {proc.stderr}")
 
         if proc.returncode != 0:
             raise RuntimeError(f"Pip install failed: {proc.stderr}")
@@ -516,7 +516,8 @@ async def load_node_metadata(deployment):
     else:
         node_data = await list_nodes(deployment.node.ip)
     deployment.node = node_data
-    logger.info(f"Node metadata loaded {deployment.node}")
+    logger.info(f"Node metadata loaded")
+    logger.debug(f"Node metadata: {deployment.node}")
 
 async def load_module_config_data(deployment: Union[AgentDeployment, ToolDeployment, EnvironmentDeployment, KBDeployment, MemoryDeployment, OrchestratorDeployment], default_deployment: Dict):
     logger.info(f"Loading module config data for {deployment.module.name}")
@@ -546,7 +547,7 @@ async def load_module_config_data(deployment: Union[AgentDeployment, ToolDeploym
 
     # update deployment with merged config
     deployment.config = merged_config
-    logger.info(f"Module config data loaded {deployment.config}")
+    logger.debug(f"Module config data loaded {deployment.config}")
 
     if 'persona_module' in merged_config and merged_config['persona_module'] is not None:
         persona_module = merged_config['persona_module']
@@ -560,7 +561,7 @@ async def load_module_config_data(deployment: Union[AgentDeployment, ToolDeploym
 
 async def load_subdeployments(deployment, main_deployment_default):
     logger.info(f"Loading subdeployments for {main_deployment_default['module']['name']}")
-    logger.info(f"Main deployment default: {main_deployment_default}")
+    logger.debug(f"Main deployment default: {main_deployment_default}")
 
     module_path = Path(f"{MODULES_SOURCE_DIR}/{main_deployment_default['module']['name']}/{main_deployment_default['module']['name']}")
 
@@ -593,7 +594,7 @@ async def load_subdeployments(deployment, main_deployment_default):
             kb_deployment = await setup_module_deployment("kb", module_path / "configs/kb_deployments.json", deployment_name, deployment.kb_deployments[i])
             kb_deployments.append(kb_deployment)
         deployment.kb_deployments = kb_deployments
-    logger.info(f"Subdeployments loaded {deployment}")
+    logger.debug(f"Subdeployments loaded {deployment}")
     if hasattr(deployment, "memory_deployments") and deployment.memory_deployments:
         memory_deployments = []
         for i, memory_deployment in enumerate(deployment.memory_deployments):
@@ -601,12 +602,12 @@ async def load_subdeployments(deployment, main_deployment_default):
             memory_deployment = await setup_module_deployment("memory", module_path / "configs/memory_deployments.json", deployment_name, deployment.memory_deployments[i])
             memory_deployments.append(memory_deployment)
         deployment.memory_deployments = memory_deployments
-    logger.info(f"Subdeployments loaded {deployment}")
+    logger.debug(f"Subdeployments loaded {deployment}")
     return deployment
 
 async def setup_module_deployment(module_type: str, main_deployment_default_path: str, deployment_name: str, deployment: Union[AgentDeployment, ToolDeployment, EnvironmentDeployment, KBDeployment, OrchestratorDeployment]):
     logger.info(f"Setting up module deployment for {deployment_name}")
-    logger.info(f"Deployment: {deployment}")
+    logger.debug(f"Deployment: {deployment}")
 
     # Map deployment types to their corresponding classes
     deployment_map = {

--- a/node/server/grpc_server.py
+++ b/node/server/grpc_server.py
@@ -51,7 +51,7 @@ class GrpcServerServicer(grpc_server_pb2_grpc.GrpcServerServicer):
         logger.info(f"Checking user: {request.public_key}")
         input_data = {"public_key": request.public_key}
         _, user_data = await check_user(input_data)
-        logger.info(f"User check result: {user_data}")
+        logger.debug(f"User check result: {user_data}")
         return grpc_server_pb2.CheckUserResponse(**user_data)
 
     async def RegisterUser(self, request, context):
@@ -59,7 +59,7 @@ class GrpcServerServicer(grpc_server_pb2_grpc.GrpcServerServicer):
         input_data = {"public_key": request.public_key}
         success, user_data = await register_user(input_data)
         if success:
-            logger.info(f"User registration result: {user_data}")
+            logger.debug(f"User registration result: {user_data}")
             return grpc_server_pb2.RegisterUserResponse(**user_data)
         else:
             context.set_code(grpc.StatusCode.INTERNAL)
@@ -90,7 +90,7 @@ class GrpcServerServicer(grpc_server_pb2_grpc.GrpcServerServicer):
             if not module_type:
                 raise Exception("Invalid module deployment type")
 
-            logger.info(f"Creating {module_type}: {module_deployment}")
+            logger.info(f"Creating {module_type}")
 
             main_module_name = module_deployment.module['name'] if isinstance(module_deployment.module, dict) else module_deployment.module.name
             main_module_path = Path(f"{MODULES_SOURCE_DIR}/{main_module_name}/{main_module_name}")

--- a/node/server/http_server.py
+++ b/node/server/http_server.py
@@ -399,7 +399,8 @@ class HTTPServer:
         Unified method to create and install any type of module and its sub-modules
         """
         try:
-            logger.info(f"Creating {module_deployment.module['module_type']}: {module_deployment}")
+            logger.info(f"Creating {module_deployment.module['module_type']}")
+            logger.debug(f"{module_deployment.module['module_type']} module_deployment: {module_deployment}")
 
             main_module_name = module_deployment.module['name']
             main_module_path = Path(f"{MODULES_SOURCE_DIR}/{main_module_name}/{main_module_name}")
@@ -448,7 +449,8 @@ class HTTPServer:
                 
             module_type = module_run_input.deployment.module.module_type
 
-            logger.info(f"Received request to run {module_type}: {module_run_input}")
+            logger.info(f"Received request to run {module_type}")
+            logger.debug(f"Run {module_type} input: {module_run_input}")
 
             user_public_key = await get_user_public_key(module_run_input.consumer_id)
 
@@ -469,7 +471,7 @@ class HTTPServer:
                     raise HTTPException(status_code=500, detail=f"Failed to create {module_type} run")
                 module_run_data = module_run.model_dump()
 
-                logger.info(f"{module_type.capitalize()} run data: {module_run_data}")
+                logger.debug(f"{module_type.capitalize()} run data: {module_run_data}")
 
             await self.register_user_on_worker_nodes(module_run)
 
@@ -608,15 +610,16 @@ class HTTPServer:
             logger.info(f"Found {module_type} status: {module_run.status}")
 
             if module_run.status == "completed":
-                logger.info(f"{module_type.capitalize()} run completed. Returning output: {module_run.results}")
+                logger.info(f"{module_type.capitalize()} run completed.")
+                logger.debug(f"Returning output: {module_run.results}")
                 response = module_run.results
             elif module_run.status == "error":
-                logger.info(f"{module_type.capitalize()} run failed. Returning error: {module_run.error_message}")
+                logger.error(f"{module_type.capitalize()} run failed. Returning error: {module_run.error_message}")
                 response = module_run.error_message
             else:
                 response = None
 
-            logger.info(f"Response: {response}")
+            logger.debug(f"Response: {response}")
             return module_run
 
         except HTTPException:

--- a/node/server/server.py
+++ b/node/server/server.py
@@ -51,7 +51,7 @@ class NodeServer:
                         await hub.delete_node(node_id=node_id)
                         logger.info(f"Cleaned up existing node registration: {node_id}")
                     except Exception as e:
-                        logger.info(f"No existing node to clean up: {e}")
+                        logger.error(f"No existing node to clean up: {e}")
                     
                     # Create http server records first
                     server_records = []
@@ -72,7 +72,7 @@ class NodeServer:
                             "port": self.node_config.servers[i].port
                         })
 
-                    logger.info(f"Server records: {server_records}")
+                    logger.debug(f"Server records: {server_records}")
 
                     # Now register the node
                     self.node_config = await hub.create_node(node_config=self.node_config, servers=server_records)
@@ -207,7 +207,7 @@ class NodeServer:
             logger.error(f"Error during {self.communication_protocol} server shutdown: {e}")
         finally:
             # Give time for cleanup operations to complete
-            logger.info("Cleanup delay before exit...")
+            logger.debug("Cleanup delay before exit...")
             await asyncio.sleep(1)
             logger.info(f"Forcing exit of {self.communication_protocol} server...")
             os._exit(0)

--- a/node/server/ws_server.py
+++ b/node/server/ws_server.py
@@ -225,7 +225,8 @@ class WebSocketServer:
             if not module_type:
                 raise HTTPException(status_code=400, detail="Invalid module deployment type")
 
-            logger.info(f"Creating {module_type}: {module_deployment}")
+            logger.info(f"Creating {module_type}")
+            logger.debug(f"{module_type}: {module_deployment}")
 
             main_module_name = module_deployment.module['name'] if isinstance(module_deployment.module, dict) else module_deployment.module.name
             main_module_path = Path(f"{MODULES_SOURCE_DIR}/{main_module_name}/{main_module_name}")
@@ -336,7 +337,7 @@ class WebSocketServer:
 
             config = module_configs[module_type]
             run_input = config["input_class"](**data)
-            logger.info(f"Received task: {run_input}")
+            logger.debug(f"Received task: {run_input}")
 
             if not run_input.deployment.initialized:
                 deployment = await self.create_module(run_input.deployment)

--- a/node/storage/db/db.py
+++ b/node/storage/db/db.py
@@ -180,7 +180,8 @@ class LocalDBPostgres:
                 db.add(run)
                 db.flush()
                 db.refresh(run)
-                logger.info(f"Created {run_type} run: {run.__dict__}")
+                logger.info(f"Created {run_type} run")
+                logger.debug(f"{run_type} run: {run.__dict__}")
                 return Schema(**run.__dict__)
         except SQLAlchemyError as e:
             logger.error(f"Failed to create {run_type} run: {str(e)}")

--- a/node/storage/db/init_db.py
+++ b/node/storage/db/init_db.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from node.storage.db.models import Base
 
 load_dotenv()
+logger = logging.getLogger(__name__)
 
 file_path = Path(__file__).parent.resolve()
 alembic_ini_path = file_path / "alembic.ini"
@@ -49,7 +50,7 @@ def init_db():
     logging.info("Creating models if they don't already exist...")
     Base.metadata.create_all(engine)
 
-    print("Database initialization complete.")
+    logger.info("Database initialization complete.")
 
 if __name__ == "__main__":
     init_db()

--- a/node/storage/db/reset_db.py
+++ b/node/storage/db/reset_db.py
@@ -3,8 +3,10 @@ import os
 import platform
 import subprocess
 import sys
+import logging
 
 load_dotenv()
+logger = logging.getLogger(__name__)
 
 LOCAL_DB_POSTGRES_USERNAME = os.getenv("LOCAL_DB_POSTGRES_USERNAME")
 LOCAL_DB_POSTGRES_PASSWORD = os.getenv("LOCAL_DB_POSTGRES_PASSWORD")
@@ -12,7 +14,7 @@ LOCAL_DB_POSTGRES_NAME = os.getenv("LOCAL_DB_POSTGRES_NAME")
 LOCAL_DB_POSTGRES_PORT = os.getenv("LOCAL_DB_POSTGRES_PORT")
 
 def reset_db():
-    print("Starting database reset...")
+    logger.info("Starting database reset...")
     
     is_macos = platform.system() == 'Darwin'
     
@@ -38,7 +40,7 @@ def reset_db():
             f"sudo -u postgres psql -d template1 -c \"ALTER USER {LOCAL_DB_POSTGRES_USERNAME} CREATEDB;\""
         ]
 
-    print("Executing database commands...")
+    logger.info("Executing database commands...")
     for cmd in commands:
         try:
             result = subprocess.run(
@@ -49,17 +51,17 @@ def reset_db():
                 stderr=subprocess.PIPE,
                 text=True
             )
-            print(f"✓ {cmd}")
+            logger.debug(f"✓ {cmd}")
         except subprocess.CalledProcessError as e:
-            print(f"\nError executing: {cmd}")
-            print(f"Exit code: {e.returncode}")
+            logger.error(f"\nError executing: {cmd}")
+            logger.error(f"Exit code: {e.returncode}")
             if e.stdout:
-                print(f"stdout: {e.stdout}")
+                logger.error(f"stdout: {e.stdout}")
             if e.stderr:
-                print(f"stderr: {e.stderr}")
+                logger.error(f"stderr: {e.stderr}")
             sys.exit(1)
 
-    print("Database reset complete!")
+    logger.info("Database reset complete!")
 
 if __name__ == "__main__":
     reset_db()

--- a/node/storage/hub/hub.py
+++ b/node/storage/hub/hub.py
@@ -148,7 +148,7 @@ class HubDBSurreal(AsyncMixin):
         """Create a server record in the database"""
         logger.info(f"Creating server: {server_config}")
         server = await self.surrealdb.create("server", server_config)
-        logger.info(f"created server: {server}")
+        logger.debug(f"created server: {server}")
         if isinstance(server, dict):
             return server
         return server[0]
@@ -168,7 +168,7 @@ class HubDBSurreal(AsyncMixin):
 
         logger.info(f"Creating node: {node_config}")
         self.node_config = await self.surrealdb.create(node_id, node_config)
-        logger.info(f"Created node: {self.node_config}")
+        logger.debug(f"Created node: {self.node_config}")
         
         if self.node_config is None:
             raise Exception("Failed to register node")
@@ -360,7 +360,7 @@ class HubDBSurreal(AsyncMixin):
 
                     results = await self.surrealdb.query(transaction_query, params)
 
-                    logger.info(f"Results: {results}")
+                    logger.debug(f"Results: {results}")
 
                     if all(result.get('status') == 'OK' for result in results) and any(result.get('result') for result in results):
                         return "Records updated successfully"

--- a/node/storage/hub/init_hub.py
+++ b/node/storage/hub/init_hub.py
@@ -55,7 +55,7 @@ def import_surql():
                     {file}"""
 
         try:
-            logger.info(f"Importing {file.rsplit('/', 1)[-1]}")
+            logger.debug(f"Importing {file.rsplit('/', 1)[-1]}")
             process = subprocess.Popen(
                 command,
                 shell=True,
@@ -64,8 +64,8 @@ def import_surql():
                 text=True,
             )
             out, err = process.communicate()
-            logger.info(out)
-            logger.info(err)
+            logger.debug(out)
+            logger.debug(err)
         except Exception as e:
             logger.error("Error creating scope")
             logger.error(str(e))
@@ -137,12 +137,16 @@ async def user_setup_flow():
         match user, username_exists, password_exists, existing_public_key_user:
             case _, True, _, True:
                 # Public key exists and doesn't match the provided username and password
+                logger.error(
+                    f"Public key {public_key} exists but doesn't match the provided username ({username}) and password"
+                )
                 raise Exception(
                     f"User with public key {public_key} already exists but doesn't match the provided username and password. Please use a different private key (or set blank in the .env file to randomly generate with launch.sh)."
                 )
 
             case _, False, False, True:
                 # Public key exists and no username/password provided
+                logger.error(f"Public key {public_key} exists but no username/password provided")
                 raise Exception(
                     f"User with public key {public_key} already exists. Cannot create new user. Please use a different private key (or set blank in the .env file to randomly generate with launch.sh)."
                 )
@@ -162,7 +166,7 @@ async def user_setup_flow():
                 while True:
                     username = input("Enter username: ")
                     password = getpass.getpass("Enter password: ") 
-                    print(f"Signing up user: {username} with public key: {public_key}")
+                    logger.info(f"Signing up user: {username} with public key: {public_key}")
                     success, token, user_id = await hub.signup(
                         username, password, public_key
                     )
@@ -175,7 +179,7 @@ async def user_setup_flow():
 
             case None, True, True, False:
                 # User doesn't exist but credentials are provided
-                print(f"Signing up user: {username} with public key: {public_key}")
+                logger.info(f"Signing up user: {username} with public key: {public_key}")
                 success, token, user_id = await hub.signup(
                     username, password, public_key
                 )

--- a/node/storage/server.py
+++ b/node/storage/server.py
@@ -26,8 +26,8 @@ async def create_storage_object(
     """Create new storage objects (table, file, or IPFS content)"""
     request_data = json.loads(request_data) if request_data else None
 
-    logger.info(f"Received data: {request_data}")
-    logger.info(f"Received file: {file}")
+    logger.debug(f"Received data: {request_data}")
+    logger.debug(f"Received file: {file}")
 
     location = StorageLocation(storage_type=storage_type, path=path)
     
@@ -245,8 +245,8 @@ async def update_storage_object(
     request_data = json.loads(request_data) if request_data else None
     condition_dict = json.loads(condition) if condition else None
 
-    logger.info(f"Received update data: {request_data}")
-    logger.info(f"Received condition: {condition_dict}")
+    logger.debug(f"Received update data: {request_data}")
+    logger.debug(f"Received condition: {condition_dict}")
 
     location = StorageLocation(storage_type=storage_type, path=path)
     

--- a/node/user.py
+++ b/node/user.py
@@ -39,7 +39,7 @@ async def check_user(user_input: Dict) -> Tuple[bool, Dict]:
         user_data["is_registered"] = True
         return True, user_data
     else:
-        logger.info("No user found.")
+        logger.error("No user found.")
         user_data = user_input.copy()
         user_data["is_registered"] = False
         return False, user_data
@@ -51,7 +51,7 @@ async def get_user_public_key(user_id: str) -> str | None:
     if public_key:
         return public_key
     else:
-        logger.info("No user found.")
+        logger.error("No user found.")
         return None
 
 def get_public_key(private_key_hex):

--- a/node/utils.py
+++ b/node/utils.py
@@ -22,7 +22,7 @@ MODELS = os.getenv("VLLM_MODELS").split(",") if os.getenv("LLM_BACKEND") == "vll
 PROVIDER_TYPES=["models", "storage", "modules"]
 VRAM = 0 
 
-def setup_logging(default_level=logging.INFO):
+def setup_logging(logging_level=logging.INFO):
     """Setup logging configuration"""
     global _logging_initialized
     if _logging_initialized:
@@ -51,7 +51,7 @@ def setup_logging(default_level=logging.INFO):
         "loggers": {
             "": {  # root logger
                 "handlers": ["console"],
-                "level": default_level,
+                "level": logging_level,
                 "propagate": True,
             }
         },

--- a/node/utils.py
+++ b/node/utils.py
@@ -106,7 +106,7 @@ def create_output_dir(base_output_dir):
 
 def run_subprocess(cmd: List) -> str:
     """Run a subprocess"""
-    logger.info(f"Running subprocess: {cmd}")
+    logger.debug(f"Running subprocess: {cmd}")
     try:
         process = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
@@ -115,7 +115,7 @@ def run_subprocess(cmd: List) -> str:
 
         # Log the output
         if out:
-            logger.info(f"Subprocess output: {out}")
+            logger.debug(f"Subprocess output: {out}")
 
         # Check if there's any stderr output
         if err:
@@ -161,7 +161,7 @@ def add_credentials_to_env(username, password):
     with open(env_file_path, "w") as env_file:
         env_file.writelines(updated_lines)
 
-    print(
+    logger.info(
         "Your credentials have been updated in the .env file. You can now use these credentials to authenticate in future sessions."
     )
 
@@ -215,5 +215,5 @@ def get_node_config():
         ram=psutil.virtual_memory().total,
         vram=VRAM,
     )
-    print("Created node config:", node_config)
+    logger.debug("Created node config:", node_config)
     return node_config

--- a/node/worker/docker_worker.py
+++ b/node/worker/docker_worker.py
@@ -85,7 +85,7 @@ def monitor_container_logs(
 
 def cleanup_container(container: Container) -> None:
     """Cleanup a container"""
-    logger.info(f"Removing container: {container}")
+    logger.debug(f"Removing container: {container}")
     if container:
         container.stop()
         container.remove()
@@ -101,7 +101,7 @@ def run_container_agent(agent_run: AgentRun = None, **kwargs) -> None:
         agent_run.inputs.input_dir
         or agent_run.inputs.input_ipfs_hash
     ):
-        logger.info("Preparing input directory")
+        logger.debug("Preparing input directory")
         inp_vol = prepare_volume_directory(
             base_dir=BASE_OUTPUT_DIR,
             bind_path=agent_run.inputs.bind_input_dir,

--- a/node/worker/package_worker.py
+++ b/node/worker/package_worker.py
@@ -109,8 +109,7 @@ async def _run_module_async(module_run: Union[AgentRun, MemoryRun, ToolRun, Orch
         module_name = module_run_engine.module["name"]
         module = module_run.deployment.module
 
-        logger.info(f"Received {module_run_engine.module_type} run: {module_run}")
-        logger.info(f"Checking if {module_run_engine.module_type} {module_name} version {module_version} is installed")
+        logger.info(f"Received {module_run_engine.module_type} run: {module_run} - Checking if {module_run_engine.module_type} {module_name} version {module_version} is installed")
 
         try:
             await install_module_with_lock(module)
@@ -224,9 +223,9 @@ class ModuleLoader:
             if env_vars:
                 os.environ.update(env_vars)
             
-            logger.info(f"Modified sys.path: {sys.path[:2]}")
-            logger.info(f"Current working directory: {os.getcwd()}")
-            logger.info(f"Injected user env data")
+            logger.debug(f"Modified sys.path: {sys.path[:2]}")
+            logger.debug(f"Current working directory: {os.getcwd()}")
+            logger.debug(f"Injected user env data")
             
             yield
             
@@ -329,9 +328,9 @@ class ModuleRunEngine:
             
             # Log package structure
             logger.info(f"Checking module structure...")
-            logger.info(f"__init__.py exists: {(module_dir / self.module_name / '__init__.py').exists()}")
-            logger.info(f"schemas.py exists: {(module_dir / self.module_name / 'schemas.py').exists()}")
-            logger.info(f"Module directory contents: {list((module_dir / self.module_name).glob('*'))}")
+            logger.debug(f"__init__.py exists: {(module_dir / self.module_name / '__init__.py').exists()}")
+            logger.debug(f"schemas.py exists: {(module_dir / self.module_name / 'schemas.py').exists()}")
+            logger.debug(f"Module directory contents: {list((module_dir / self.module_name).glob('*'))}")
 
             # Get entrypoint name
             entrypoint = self.module['module_entrypoint'].split('.')[0] if 'module_entrypoint' in self.module else 'run'

--- a/node/worker/utils.py
+++ b/node/worker/utils.py
@@ -50,9 +50,9 @@ def handle_ipfs_input(ipfs_hash: str) -> str:
     try:
         unzip_file(Path(downloaded_path), Path(temp_dir))
         os.remove(downloaded_path)
-        logger.info(f"Unzipped file: {downloaded_path}")
+        logger.debug(f"Unzipped file: {downloaded_path}")
     except Exception:
-        logger.info(f"File is not a zip file: {downloaded_path}")
+        logger.error(f"File is not a zip file: {downloaded_path}")
     if os.path.isdir(os.path.join(temp_dir, ipfs_hash)):
         return os.path.join(temp_dir, ipfs_hash)
     else:
@@ -64,7 +64,7 @@ def upload_to_ipfs(input_dir: str) -> str:
     logger.info(f"Uploading to IPFS: {input_dir}")
     client = ipfshttpclient.connect(IPFS_GATEWAY_URL)
     res = client.add(input_dir, recursive=True)
-    logger.info(f"IPFS add response: {res}")
+    logger.debug(f"IPFS add response: {res}")
     ipfs_hash = res[-1]["Hash"]
     client.pin.add(ipfs_hash)
     return ipfs_hash
@@ -75,7 +75,7 @@ def upload_json_string_to_ipfs(json_string: str) -> str:
     logger.info("Uploading json string to IPFS")
     client = ipfshttpclient.connect(IPFS_GATEWAY_URL)
     res = client.add_str(json_string)
-    logger.info(f"IPFS add response: {res}")
+    logger.debug(f"IPFS add response: {res}")
     client.pin.add(res)
     return res
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3662,4 +3662,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "c370078861d46c58b0f5cb61db2f2907b102f8c21f89359b7516a14e666af913"
+content-hash = "4674df1a13d2dba95a1a9366000be45a9ce874e3c59efba17fc30770e526d224"


### PR DESCRIPTION
To clean up logs this PR converts many logger prints from INFO to DEBUG. Some INFO to ERROR too. 

The idea is to log:

- as INFO general steps like "Starting server...", "Request received..."
- as DEBUG detailed stuff that'd be useful in actual debugging like full objects e.g. `node=NodeConfigInput(ip='localhost', user_communication_port=None, user_communication_protocol=None) name='agent_deployment_2' module ... `, model full response, verbose stuff
- as ERROR anything that's worth raising a red flag for, even if an exception is NOT raised but something unexpected happens. It'll help spotting corner cases, plus, platform like graphana can highlight, search and count ERROR logs to gauge the healthiness of the sysyem